### PR TITLE
Fix panel visibility on icon click

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -449,6 +449,22 @@ document.addEventListener('DOMContentLoaded', function() {
 
   // Fade button functionality
   if (fadeButton) {
+    // Handle taps on mobile to avoid document-level touchstart toggling back
+    fadeButton.addEventListener('touchstart', function(event) {
+      // Ensure this does not bubble to document touchstart
+      event.stopPropagation();
+      // Prevent the subsequent synthetic click
+      event.preventDefault();
+
+      if (isControlsVisible) {
+        hideControls();
+      } else {
+        showControls();
+        scheduleHide();
+      }
+    }, { passive: false });
+
+    // Handle clicks (desktop and fallback)
     fadeButton.addEventListener('click', function(event) {
       // Prevent this click from triggering the page-wide show controls
       event.stopPropagation();
@@ -464,7 +480,7 @@ document.addEventListener('DOMContentLoaded', function() {
       }
     });
     
-    console.log('✅ Fade button event listener attached');
+    console.log('✅ Fade button event listeners attached');
   } else {
     console.log('⚠️ Fade button not found');
   }


### PR DESCRIPTION
Add touchstart handler to fade button to reliably show/hide panel on mobile.

The existing click handler on the fade button was not reliably showing the panel on mobile devices when it was hidden, due to interference from document-level `touchstart` handlers. Adding a dedicated `touchstart` listener with `stopPropagation` and `preventDefault` ensures the panel toggles correctly on mobile taps.

---
<a href="https://cursor.com/background-agent?bcId=bc-4eeea10e-9d5c-4b78-b617-3ed00cf2aa14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4eeea10e-9d5c-4b78-b617-3ed00cf2aa14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

