### PR TITLE
Add Hourly panel and improve mobile UX

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,16 +49,17 @@ This file captures project knowledge and guardrails so agents can make safe, hig
 
 - `js/hourlyPanel.js` → Hourly tiles panel
   - No Plotly (like `actuals`); pure DOM under `#plot`.
-  - Vertical day groups, each a horizontal `scroll-snap` row of hour tiles.
-  - Per tile: weather symbol, temp, UV, wind (speed + direction arrow), precip prob + amount.
-  - Starts at the current Berlin hour; first tile marked "Now". Reuses `WeatherIcons` + plot.js wind-arrow convention.
+  - Vertical day groups, each a horizontal `scroll-snap` row of tiles.
+  - Tiles default to every `STEP_H` (3) hours; tapping a tile toggles `expanded` (a module Set keyed by `date-blockIndex`) and re-renders in place, drilling that block into its individual hours. `lastRender` holds the last args for the in-place re-render; scroll positions are preserved.
+  - Per tile: weather symbol, temp (blue→red colour scale), UV, wind (speed + direction arrow), precip prob + amount bar. Day/night tint via hourly `is_day` (fallback: sunrise/sunset). Sunrise/sunset marker tiles inserted by time.
+  - Starts at the current Berlin hour; first tile marked "Now". Reuses `WeatherIcons` + plot.js wind-arrow convention. `is_day` is requested in `api.js` hourly vars.
 
 - `js/overviewPanel.js` → Calendar overview panel
   - Async render; fetches BrightSky past days for current week in parallel.
   - 7-column Mon–Sun grid; `min-width: 980px` container + `#plot overflow-x: auto`.
 
 - `js/swipeNavigation.js` → Swipe/keyboard panning
-  - Horizontal swipe left → later time (map-drag convention); up/down cycles panels.
+  - Horizontal swipe left → later time (map-drag convention). Vertical swipe is intentionally ignored (it collided with scrolling); panel switching is via the dropdown or ↑/↓ keys (in main.js).
   - Arrow left/right keys pan; always active (no controls-hidden gate).
   - Every range change saves to `window._savedXRange`; `window.applyActiveView()` restores after render.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,12 @@ This file captures project knowledge and guardrails so agents can make safe, hig
   - Fetches multiple models in parallel; state persists across re-renders.
   - Symbol size restyles dynamically via `Plotly.restyle` when view range changes.
 
+- `js/hourlyPanel.js` → Hourly tiles panel
+  - No Plotly (like `actuals`); pure DOM under `#plot`.
+  - Vertical day groups, each a horizontal `scroll-snap` row of hour tiles.
+  - Per tile: weather symbol, temp, UV, wind (speed + direction arrow), precip prob + amount.
+  - Starts at the current Berlin hour; first tile marked "Now". Reuses `WeatherIcons` + plot.js wind-arrow convention.
+
 - `js/overviewPanel.js` → Calendar overview panel
   - Async render; fetches BrightSky past days for current week in parallel.
   - 7-column Mon–Sun grid; `min-width: 980px` container + `#plot overflow-x: auto`.
@@ -63,7 +69,7 @@ This file captures project knowledge and guardrails so agents can make safe, hig
 - Query params define the entire app state:
   - `lat`, `lon`, `name` (location)
   - `model` (one of `models[].id` in `main.js`)
-  - `panel` (`compare`, `temperature`, `uv_wind`, `overview`, `actuals`) — default `compare`
+  - `panel` (`compare`, `temperature`, `uv_wind`, `overview`, `actuals`, `hourly`) — default `compare`
   - `view` (`1d`, `2d`, `5d`, `all`)
 - Always use `updateUrlWithAppState()` when programmatically changing selections to keep history, back/forward, and deep links consistent.
 - `popstate` handler restores selections and triggers a re‑render; `restoreViewFromUrl(view)` handles `view` after render.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A mobile-friendly weather forecast app with multiple models, interactive charts,
 | Panel | Description |
 |---|---|
 | 🔀 **Compare** *(default)* | Overlay multiple forecast models side by side with temperature, rain, wind, UV, symbols |
-| 🕒 **Hourly** | Mobile-friendly swipeable hour tiles — weather symbol, temperature, UV, wind (speed + direction), precipitation probability & amount; grouped by day, "Now" highlighted |
+| 🕒 **Hourly** | Mobile-friendly swipeable tiles (every 3h by default — tap a tile to expand into hourly detail): weather symbol, temperature (colour-scaled), UV, wind (speed + direction), precipitation probability & amount. Day/night tinting, sunrise/sunset markers, "Now" highlighted |
 | 🌡️ **Temperature** | Hourly temperature, precipitation, cloud cover, humidity, visibility with observed overlays |
 | ☀️ **UV & Wind** | UV index and wind speed/gusts with Beaufort scale; wind direction shown as arrows on the wind trace |
 | 📅 **Overview** | Calendar grid (Mon–Sun weeks); today highlighted; weekends tinted; past days filled with BrightSky observed data |

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A mobile-friendly weather forecast app with multiple models, interactive charts,
 | Panel | Description |
 |---|---|
 | 🔀 **Compare** *(default)* | Overlay multiple forecast models side by side with temperature, rain, wind, UV, symbols |
+| 🕒 **Hourly** | Mobile-friendly swipeable hour tiles — weather symbol, temperature, UV, wind (speed + direction), precipitation probability & amount; grouped by day, "Now" highlighted |
 | 🌡️ **Temperature** | Hourly temperature, precipitation, cloud cover, humidity, visibility with observed overlays |
 | ☀️ **UV & Wind** | UV index and wind speed/gusts with Beaufort scale; wind direction shown as arrows on the wind trace |
 | 📅 **Overview** | Calendar grid (Mon–Sun weeks); today highlighted; weekends tinted; past days filled with BrightSky observed data |

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <title>⛅ Forecast</title>
   <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <style>
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -25,6 +25,10 @@
       backdrop-filter: blur(10px);
       -webkit-backdrop-filter: blur(10px);
       padding: 10px;
+      /* Keep controls clear of the notch / Dynamic Island */
+      padding-top: calc(10px + env(safe-area-inset-top));
+      padding-left: calc(10px + env(safe-area-inset-left));
+      padding-right: calc(10px + env(safe-area-inset-right));
       border-radius: 0 0 15px 15px;
       box-shadow: 0 2px 15px rgba(0, 0, 0, 0.15);
       z-index: 100;
@@ -68,7 +72,7 @@
     /* 🔹 Mobile Plot Container */
     #plot {
       width: 100vw;
-      height: 100vh; /* Full height when controls fade */
+      height: 100dvh; /* Dynamic viewport height — avoids URL-bar jump on mobile */
       margin-top: 0; /* No margin when controls fade */
       transition: margin-top 0.3s ease;
       position: relative;
@@ -134,22 +138,34 @@
 
     /* Mobile-specific styles */
     @media (max-width: 768px) {
+      /* Tighten the bar so the chart gets more height; the 👁️ button still hides it entirely */
       #controls {
-        padding: 8px;
-        gap: 6px;
+        padding: 6px;
+        padding-top: calc(6px + env(safe-area-inset-top));
+        gap: 5px;
       }
-      
+
       select,
       #status {
         font-size: 13px;
         padding: 6px 10px;
+        min-height: 40px;
       }
-      
+
+      /* Compact view buttons so 1d/2d/5d/All/◀/▶ fit on a single row */
       .view-btn {
-        padding: 8px 12px;
+        padding: 6px 8px;
         font-size: 13px;
+        min-height: 40px;
+        min-width: 38px;
+        margin: 0 2px;
       }
-      
+
+      /* Less gap between row 1 and the model row */
+      #model-row {
+        margin-top: 5px !important;
+      }
+
       /* Hide Plotly toolbar controls on mobile */
       .plotly .modebar {
         display: none !important;
@@ -187,8 +203,8 @@
     /* 🔹 Always-visible Fade Toggle Button (top-right) */
     #fade-button {
       position: fixed;
-      top: 10px;
-      right: 10px;
+      top: calc(10px + env(safe-area-inset-top));
+      right: calc(10px + env(safe-area-inset-right));
       z-index: 200; /* Above controls (100) and fade-trigger (99) */
       width: 44px;
       height: 44px;
@@ -207,8 +223,8 @@
 
     #help-button {
       position: fixed;
-      top: 10px;
-      right: 60px;
+      top: calc(10px + env(safe-area-inset-top));
+      right: calc(60px + env(safe-area-inset-right));
       z-index: 200;
       width: 22px;
       height: 22px;
@@ -280,6 +296,7 @@
         <label for="panelSelect">📊</label>
         <select id="panelSelect">
           <option value="overview">📅 Overview</option>
+          <option value="hourly">🕒 Hourly</option>
           <option value="temperature">🌡️ Temperature</option>
           <option value="uv_wind">☀️ UV & Wind</option>
           <option value="actuals">📍 Actuals</option>
@@ -314,6 +331,7 @@
   <script src="./js/plot.js"></script>
   <script src="./js/visRegistry.js"></script>
   <script src="./js/overviewPanel.js"></script>
+  <script src="./js/hourlyPanel.js"></script>
   <script src="./js/comparePanel.js"></script>
   <script src="./js/locationPicker.js"></script>
   <script src="./js/locationSearch.js"></script>

--- a/js/api.js
+++ b/js/api.js
@@ -432,14 +432,14 @@ window.WeatherAPI.getForecastData = async function(location, model) {
   if (model.type === "ensemble") {
     hourlyVars = [
       "temperature_2m", "relative_humidity_2m",
-      "precipitation", "cloud_cover", "weather_code",
+      "precipitation", "cloud_cover", "weather_code", "is_day",
       "uv_index", "uv_index_clear_sky", "wind_speed_10m", "wind_direction_10m", "wind_gusts_10m"
     ];
     apiUrl = `https://ensemble-api.open-meteo.com/v1/ensemble?`;
   } else {
     hourlyVars = [
       "temperature_2m", "relative_humidity_2m", "dew_point_2m",
-      "precipitation", "precipitation_probability", "weather_code",
+      "precipitation", "precipitation_probability", "weather_code", "is_day",
       "cloud_cover", "cloud_cover_low", "cloud_cover_mid",
       "cloud_cover_high", "visibility", "sunshine_duration",
       "uv_index", "uv_index_clear_sky", "wind_speed_10m", "wind_direction_10m", "wind_gusts_10m"

--- a/js/comparePanel.js
+++ b/js/comparePanel.js
@@ -97,7 +97,10 @@ window.ComparePanel = {
 
     Plotly.newPlot('compare-chart', traces, layout, {
       responsive: true,
-      displayModeBar: false
+      displayModeBar: false,
+      // Custom view buttons own the x-range; stop tap/double-tap from resetting it.
+      doubleClick: false,
+      scrollZoom: false
     }).then(() => {
       if (typeof window.applyActiveView === 'function') window.applyActiveView();
     });

--- a/js/hourlyPanel.js
+++ b/js/hourlyPanel.js
@@ -1,0 +1,231 @@
+/**
+ * Hourly Panel — mobile-friendly swipeable hour tiles
+ *
+ * Renders a vertical list of days; each day is a horizontally scroll-snapping
+ * row of compact hour tiles. Each tile shows: hour, weather symbol, temperature,
+ * UV index, wind (speed + direction arrow), and precipitation (probability + amount).
+ *
+ * No Plotly — pure DOM under #plot (same pattern as the actuals panel), so it
+ * sidesteps the mobile sizing/viewport issues that affect the chart panels.
+ *
+ * Signature: render(data, location, model, config)
+ *   data.forecast.hourly.{ time, temperature_2m, weather_code, uv_index,
+ *                          wind_speed_10m, wind_direction_10m, wind_gusts_10m,
+ *                          precipitation, precipitation_probability }
+ */
+window.HourlyPanel = (function () {
+  // Same convention as plot.js: arrow points where the wind is coming FROM.
+  function windDirToArrow(deg) {
+    if (deg == null || Number.isNaN(deg)) return '';
+    const d = ((deg % 360) + 360) % 360;
+    if (d < 22.5 || d >= 337.5) return '↑';
+    if (d < 67.5) return '↗';
+    if (d < 112.5) return '→';
+    if (d < 157.5) return '↘';
+    if (d < 202.5) return '↓';
+    if (d < 247.5) return '↙';
+    if (d < 292.5) return '←';
+    return '↖';
+  }
+
+  function icon(code) {
+    return (window.WeatherIcons && window.WeatherIcons.getIcon)
+      ? window.WeatherIcons.getIcon(code)
+      : '·';
+  }
+
+  // API requests timezone=Europe/Berlin, so hourly.time strings are already
+  // local wall-clock ISO without offset (e.g. "2026-06-28T14:00").
+  function berlinNow() {
+    const s = new Date().toLocaleString('sv-SE', { timeZone: 'Europe/Berlin' }).replace(' ', 'T');
+    return new Date(s);
+  }
+
+  function round(v, digits = 0) {
+    if (v === null || v === undefined || Number.isNaN(v)) return null;
+    const p = Math.pow(10, digits);
+    return Math.round(v * p) / p;
+  }
+
+  function dayLabel(dateStr, todayStr, tomorrowStr) {
+    const d = new Date(dateStr + 'T12:00');
+    const weekday = d.toLocaleDateString('en-GB', { weekday: 'short' });
+    const dm = d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' });
+    if (dateStr === todayStr) return `Today · ${weekday} ${dm}`;
+    if (dateStr === tomorrowStr) return `Tomorrow · ${weekday} ${dm}`;
+    return `${weekday} ${dm}`;
+  }
+
+  function buildTile(h, isNow) {
+    const tile = document.createElement('div');
+    tile.style.cssText = [
+      'flex:0 0 auto', 'scroll-snap-align:start', 'width:62px',
+      'box-sizing:border-box', 'padding:8px 4px', 'border-radius:12px',
+      'text-align:center', 'background:' + (isNow ? '#eaf3ff' : '#f7f7f9'),
+      'border:' + (isNow ? '1.5px solid #007AFF' : '1px solid #ececf0'),
+      'display:flex', 'flex-direction:column', 'align-items:center', 'gap:2px'
+    ].join(';');
+
+    const hour = document.createElement('div');
+    hour.textContent = isNow ? 'Now' : h.hour;
+    hour.style.cssText = 'font-size:12px;font-weight:600;color:' + (isNow ? '#007AFF' : '#555');
+
+    const sym = document.createElement('div');
+    sym.textContent = icon(h.code);
+    sym.style.cssText = 'font-size:22px;line-height:1.1';
+
+    const temp = document.createElement('div');
+    temp.textContent = h.temp != null ? `${h.temp}°` : '–';
+    temp.style.cssText = 'font-size:16px;font-weight:700;color:#222';
+
+    // UV — only show when meaningful (>0, i.e. daytime)
+    const uv = document.createElement('div');
+    if (h.uv != null && h.uv >= 0.5) {
+      uv.textContent = `☀️${h.uv}`;
+      uv.style.cssText = 'font-size:11px;color:#c47f00';
+    } else {
+      uv.innerHTML = '&nbsp;';
+      uv.style.cssText = 'font-size:11px';
+    }
+
+    // Wind — speed + direction arrow
+    const wind = document.createElement('div');
+    wind.textContent = h.wind != null ? `${h.wind}${h.arrow}` : '';
+    wind.style.cssText = 'font-size:11px;color:#444;white-space:nowrap';
+    wind.title = 'Wind km/h (gust ' + (h.gust != null ? h.gust : '?') + ')';
+
+    // Precipitation — probability + amount; emphasised when wet
+    const precip = document.createElement('div');
+    const hasProb = h.pop != null && h.pop > 0;
+    const hasAmt = h.precip != null && h.precip > 0;
+    if (hasProb || hasAmt) {
+      const probTxt = h.pop != null ? `${h.pop}%` : '';
+      const amtTxt = hasAmt ? `${h.precip}mm` : '';
+      precip.innerHTML = `<div>💧${probTxt}</div>` + (amtTxt ? `<div>${amtTxt}</div>` : '');
+      precip.style.cssText = 'font-size:11px;color:#0a7cd1;font-weight:600;line-height:1.2';
+    } else {
+      precip.innerHTML = '<div>&nbsp;</div>';
+      precip.style.cssText = 'font-size:11px';
+    }
+
+    tile.appendChild(hour);
+    tile.appendChild(sym);
+    tile.appendChild(temp);
+    tile.appendChild(uv);
+    tile.appendChild(wind);
+    tile.appendChild(precip);
+    return tile;
+  }
+
+  function render(data, location, model, config = {}) {
+    const plot = document.getElementById('plot');
+    if (!plot) return;
+
+    // Clear any existing Plotly chart / DOM
+    if (window.Plotly && plot.classList && plot.classList.contains('js-plotly-plot')) {
+      try { Plotly.purge(plot); } catch (_) {}
+    }
+    plot.innerHTML = '';
+
+    const hourly = data && data.forecast && data.forecast.hourly ? data.forecast.hourly : null;
+    if (!hourly || !hourly.time || hourly.time.length === 0) {
+      const msg = document.createElement('div');
+      msg.style.cssText = 'padding:24px;text-align:center;color:#888;';
+      msg.textContent = 'No hourly forecast data available.';
+      plot.appendChild(msg);
+      return;
+    }
+
+    const now = berlinNow();
+    const todayStr = now.toLocaleDateString('sv-SE'); // YYYY-MM-DD
+    const tomorrow = new Date(now);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const tomorrowStr = tomorrow.toLocaleDateString('sv-SE');
+    const currentHourStart = new Date(now);
+    currentHourStart.setMinutes(0, 0, 0);
+
+    const T = hourly.time;
+    const temp = hourly.temperature_2m || [];
+    const code = hourly.weather_code || [];
+    const uv = hourly.uv_index || [];
+    const wind = hourly.wind_speed_10m || [];
+    const gust = hourly.wind_gusts_10m || [];
+    const dir = hourly.wind_direction_10m || [];
+    const precip = hourly.precipitation || [];
+    const pop = hourly.precipitation_probability || [];
+
+    // Build per-hour records from the current hour onward, grouped by day.
+    const days = [];
+    let lastDate = null;
+    let nowMarked = false;
+    for (let i = 0; i < T.length; i++) {
+      const t = new Date(T[i]);
+      if (t < currentHourStart) continue; // skip past hours
+      const dateStr = T[i].slice(0, 10);
+      if (dateStr !== lastDate) {
+        days.push({ dateStr, hours: [] });
+        lastDate = dateStr;
+      }
+      const isNow = !nowMarked;
+      if (isNow) nowMarked = true;
+      days[days.length - 1].hours.push({
+        hour: T[i].slice(11, 16),
+        isNow,
+        temp: round(temp[i]),
+        code: code[i],
+        uv: round(uv[i], 1),
+        wind: round(wind[i]),
+        gust: round(gust[i]),
+        arrow: windDirToArrow(dir[i]),
+        precip: round(precip[i], 1),
+        pop: round(pop[i])
+      });
+    }
+
+    const container = document.createElement('div');
+    container.style.cssText = 'padding:8px 0 24px;max-width:1100px;margin:0 auto;';
+
+    const title = document.createElement('div');
+    title.style.cssText = 'padding:6px 12px 2px;font-size:13px;color:#888;';
+    title.textContent = `${location && location.name ? location.name : ''} — hourly` +
+      (model && model.label ? ` · ${model.label}` : '');
+    container.appendChild(title);
+
+    days.forEach(day => {
+      const header = document.createElement('div');
+      header.setAttribute('data-date', day.dateStr);
+      header.textContent = dayLabel(day.dateStr, todayStr, tomorrowStr);
+      header.style.cssText = [
+        'position:sticky', 'left:0', 'padding:10px 12px 4px',
+        'font-size:14px', 'font-weight:700', 'color:#333',
+        'background:rgba(255,255,255,0.95)'
+      ].join(';');
+      container.appendChild(header);
+
+      const row = document.createElement('div');
+      row.style.cssText = [
+        'display:flex', 'gap:6px', 'overflow-x:auto', 'scroll-snap-type:x mandatory',
+        'padding:4px 12px 8px', '-webkit-overflow-scrolling:touch'
+      ].join(';');
+      day.hours.forEach(h => row.appendChild(buildTile(h, h.isNow)));
+      container.appendChild(row);
+    });
+
+    plot.appendChild(container);
+
+    // If we arrived here from an Overview day-card click, scroll that day into view.
+    const targetDate = window._hourlyScrollDate;
+    window._hourlyScrollDate = null;
+    if (targetDate) {
+      requestAnimationFrame(() => {
+        const header = container.querySelector(`[data-date="${targetDate}"]`);
+        if (!header) return;
+        const plotRect = plot.getBoundingClientRect();
+        const headerRect = header.getBoundingClientRect();
+        plot.scrollTop += headerRect.top - plotRect.top - 8;
+      });
+    }
+  }
+
+  return { render };
+})();

--- a/js/hourlyPanel.js
+++ b/js/hourlyPanel.js
@@ -1,19 +1,29 @@
 /**
- * Hourly Panel — mobile-friendly swipeable hour tiles
+ * Hourly Panel — mobile-friendly swipeable tiles
  *
- * Renders a vertical list of days; each day is a horizontally scroll-snapping
- * row of compact hour tiles. Each tile shows: hour, weather symbol, temperature,
- * UV index, wind (speed + direction arrow), and precipitation (probability + amount).
+ * Vertical list of days; each day is a horizontally scroll-snapping row of compact
+ * tiles. By default tiles are spaced every 3 hours (uniform for all days); tapping
+ * a tile expands that 3-hour block into its individual hours (and tapping again,
+ * or tapping an expanded hour, collapses it).
  *
- * No Plotly — pure DOM under #plot (same pattern as the actuals panel), so it
- * sidesteps the mobile sizing/viewport issues that affect the chart panels.
+ * Each tile shows: hour, weather symbol, temperature, UV, wind (speed + direction),
+ * and precipitation (probability + amount as a bar).
+ *
+ * Polish for time-orientation & at-a-glance feel:
+ *  - Day/night tinting via hourly `is_day` (falls back to sunrise/sunset comparison).
+ *  - Sunrise/sunset marker tiles inserted into the strip at the right hour.
+ *  - Temperature values coloured on a blue→red scale.
+ *  - Precipitation drawn as a vertical bar (height ∝ amount).
+ *
+ * No Plotly — pure DOM under #plot (same pattern as the actuals panel).
  *
  * Signature: render(data, location, model, config)
- *   data.forecast.hourly.{ time, temperature_2m, weather_code, uv_index,
- *                          wind_speed_10m, wind_direction_10m, wind_gusts_10m,
- *                          precipitation, precipitation_probability }
  */
 window.HourlyPanel = (function () {
+  const STEP_H = 3;                 // default tile spacing (hours)
+  const expanded = new Set();       // keys "YYYY-MM-DD-<blockIndex>" currently drilled-in
+  let lastRender = null;            // args of the last render(), for re-rendering on toggle
+
   // Same convention as plot.js: arrow points where the wind is coming FROM.
   function windDirToArrow(deg) {
     if (deg == null || Number.isNaN(deg)) return '';
@@ -47,6 +57,16 @@ window.HourlyPanel = (function () {
     return Math.round(v * p) / p;
   }
 
+  // Temperature → colour on a blue (cold) → red (hot) scale.
+  function tempColor(t, isDay) {
+    if (t == null) return isDay ? '#222' : '#eee';
+    const clamped = Math.max(-10, Math.min(35, t));
+    const frac = (clamped + 10) / 45;        // 0 (cold) … 1 (hot)
+    const hue = 210 * (1 - frac);            // 210° blue → 0° red
+    const light = isDay ? 42 : 64;
+    return `hsl(${Math.round(hue)}, 80%, ${light}%)`;
+  }
+
   function dayLabel(dateStr, todayStr, tomorrowStr) {
     const d = new Date(dateStr + 'T12:00');
     const weekday = d.toLocaleDateString('en-GB', { weekday: 'short' });
@@ -56,19 +76,41 @@ window.HourlyPanel = (function () {
     return `${weekday} ${dm}`;
   }
 
-  function buildTile(h, isNow) {
+  // Vertical precipitation bar whose height encodes the amount (~4 mm fills it).
+  function precipBar(amount, isDay) {
+    const track = document.createElement('div');
+    track.style.cssText = 'height:22px;display:flex;align-items:flex-end;justify-content:center;';
+    if (amount != null && amount > 0) {
+      const h = Math.max(3, Math.min(22, (amount / 4) * 22));
+      const bar = document.createElement('div');
+      bar.style.cssText = `width:10px;height:${h}px;border-radius:2px 2px 0 0;background:${isDay ? '#0a7cd1' : '#4ea8ff'};`;
+      track.appendChild(bar);
+    }
+    return track;
+  }
+
+  // Build an hour tile. `expandable` = collapsed 3h tile (shows "⋯" open hint);
+  // `expandedMember` = part of an open block (shows "▴" collapse hint).
+  function buildHourTile(h, expandable, expandedMember) {
+    const isDay = h.isDay !== 0; // treat unknown as day
     const tile = document.createElement('div');
+    const bg = h.isNow
+      ? (isDay ? '#eaf3ff' : '#33406b')
+      : (isDay ? '#f7f8fb' : '#2b3050');
     tile.style.cssText = [
-      'flex:0 0 auto', 'scroll-snap-align:start', 'width:62px',
+      'flex:0 0 auto', 'scroll-snap-align:start', 'width:64px',
       'box-sizing:border-box', 'padding:8px 4px', 'border-radius:12px',
-      'text-align:center', 'background:' + (isNow ? '#eaf3ff' : '#f7f7f9'),
-      'border:' + (isNow ? '1.5px solid #007AFF' : '1px solid #ececf0'),
+      'text-align:center', 'background:' + bg, 'cursor:pointer',
+      'border:' + (h.isNow ? '1.5px solid #007AFF' : '1px solid ' + (isDay ? '#ececf0' : '#3a4166')),
       'display:flex', 'flex-direction:column', 'align-items:center', 'gap:2px'
     ].join(';');
 
+    const subColor = isDay ? '#555' : '#c2c8e8';
+
     const hour = document.createElement('div');
-    hour.textContent = isNow ? 'Now' : h.hour;
-    hour.style.cssText = 'font-size:12px;font-weight:600;color:' + (isNow ? '#007AFF' : '#555');
+    hour.textContent = h.isNow ? 'Now' : h.hour;
+    hour.style.cssText = 'font-size:12px;font-weight:600;color:' +
+      (h.isNow ? (isDay ? '#007AFF' : '#8fb6ff') : subColor);
 
     const sym = document.createElement('div');
     sym.textContent = icon(h.code);
@@ -76,37 +118,38 @@ window.HourlyPanel = (function () {
 
     const temp = document.createElement('div');
     temp.textContent = h.temp != null ? `${h.temp}°` : '–';
-    temp.style.cssText = 'font-size:16px;font-weight:700;color:#222';
+    temp.style.cssText = `font-size:16px;font-weight:700;color:${tempColor(h.temp, isDay)}`;
 
-    // UV — only show when meaningful (>0, i.e. daytime)
     const uv = document.createElement('div');
     if (h.uv != null && h.uv >= 0.5) {
       uv.textContent = `☀️${h.uv}`;
-      uv.style.cssText = 'font-size:11px;color:#c47f00';
+      uv.style.cssText = `font-size:11px;color:${isDay ? '#c47f00' : '#ffce6b'}`;
     } else {
       uv.innerHTML = '&nbsp;';
       uv.style.cssText = 'font-size:11px';
     }
 
-    // Wind — speed + direction arrow
     const wind = document.createElement('div');
     wind.textContent = h.wind != null ? `${h.wind}${h.arrow}` : '';
-    wind.style.cssText = 'font-size:11px;color:#444;white-space:nowrap';
+    wind.style.cssText = `font-size:11px;color:${subColor};white-space:nowrap`;
     wind.title = 'Wind km/h (gust ' + (h.gust != null ? h.gust : '?') + ')';
 
-    // Precipitation — probability + amount; emphasised when wet
     const precip = document.createElement('div');
-    const hasProb = h.pop != null && h.pop > 0;
-    const hasAmt = h.precip != null && h.precip > 0;
-    if (hasProb || hasAmt) {
-      const probTxt = h.pop != null ? `${h.pop}%` : '';
-      const amtTxt = hasAmt ? `${h.precip}mm` : '';
-      precip.innerHTML = `<div>💧${probTxt}</div>` + (amtTxt ? `<div>${amtTxt}</div>` : '');
-      precip.style.cssText = 'font-size:11px;color:#0a7cd1;font-weight:600;line-height:1.2';
-    } else {
-      precip.innerHTML = '<div>&nbsp;</div>';
-      precip.style.cssText = 'font-size:11px';
-    }
+    precip.style.cssText = 'display:flex;flex-direction:column;align-items:center;gap:1px;min-height:42px;justify-content:flex-end;';
+    const prob = document.createElement('div');
+    prob.style.cssText = `font-size:11px;font-weight:600;color:${isDay ? '#0a7cd1' : '#7cc0ff'}`;
+    prob.innerHTML = (h.pop != null && h.pop > 0) ? `💧${h.pop}%` : '&nbsp;';
+    const mm = document.createElement('div');
+    mm.style.cssText = `font-size:9px;color:${isDay ? '#0a7cd1' : '#7cc0ff'}`;
+    mm.innerHTML = (h.precip != null && h.precip > 0) ? `${h.precip}mm` : '&nbsp;';
+    precip.appendChild(prob);
+    precip.appendChild(precipBar(h.precip, isDay));
+    precip.appendChild(mm);
+
+    // Affordance: "⋯" = tap to expand (collapsed 3h tile), "▴" = tap to collapse.
+    const hint = document.createElement('div');
+    hint.style.cssText = `font-size:11px;line-height:1;height:12px;color:${isDay ? '#9aa' : '#7e86ad'}`;
+    hint.textContent = expandable ? '⋯' : (expandedMember ? '▴' : '');
 
     tile.appendChild(hour);
     tile.appendChild(sym);
@@ -114,20 +157,77 @@ window.HourlyPanel = (function () {
     tile.appendChild(uv);
     tile.appendChild(wind);
     tile.appendChild(precip);
+    tile.appendChild(hint);
     return tile;
   }
 
+  function buildMarkerTile(m) {
+    const tile = document.createElement('div');
+    const sunrise = m.marker === 'sunrise';
+    tile.style.cssText = [
+      'flex:0 0 auto', 'scroll-snap-align:start', 'width:54px',
+      'box-sizing:border-box', 'padding:8px 4px', 'border-radius:12px',
+      'text-align:center', 'display:flex', 'flex-direction:column',
+      'align-items:center', 'justify-content:center', 'gap:4px',
+      'background:' + (sunrise
+        ? 'linear-gradient(180deg,#fff4d6,#ffe9c2)'
+        : 'linear-gradient(180deg,#ffe0c2,#e9c7e8)'),
+      'border:1px dashed ' + (sunrise ? '#e0b341' : '#c98fb0')
+    ].join(';');
+
+    const emo = document.createElement('div');
+    emo.textContent = sunrise ? '🌅' : '🌇';
+    emo.style.cssText = 'font-size:24px;line-height:1';
+    const lbl = document.createElement('div');
+    lbl.textContent = sunrise ? 'Sunrise' : 'Sunset';
+    lbl.style.cssText = 'font-size:9px;color:#7a5a2a;font-weight:600;text-transform:uppercase;letter-spacing:.3px';
+    const time = document.createElement('div');
+    time.textContent = m.time;
+    time.style.cssText = 'font-size:12px;font-weight:700;color:#5a3f1e';
+
+    tile.appendChild(emo);
+    tile.appendChild(lbl);
+    tile.appendChild(time);
+    return tile;
+  }
+
+  function hhmm(d) {
+    return d.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' });
+  }
+
+  function blockKey(dateStr, hourOfDay) {
+    return `${dateStr}-${Math.floor(hourOfDay / STEP_H)}`;
+  }
+
+  // Toggle a 3h block open/closed and re-render in place (keeping scroll position).
+  function toggleBlock(key) {
+    if (expanded.has(key)) expanded.delete(key); else expanded.add(key);
+    if (!lastRender) return;
+    const plot = document.getElementById('plot');
+    const st = plot ? plot.scrollTop : 0;
+    const sls = plot ? Array.from(plot.querySelectorAll('[data-row-date]')).map(r => [r.getAttribute('data-row-date'), r.scrollLeft]) : [];
+    render(lastRender.data, lastRender.location, lastRender.model, lastRender.config);
+    if (plot) {
+      plot.scrollTop = st;
+      sls.forEach(([d, x]) => {
+        const r = plot.querySelector(`[data-row-date="${d}"]`);
+        if (r) r.scrollLeft = x;
+      });
+    }
+  }
+
   function render(data, location, model, config = {}) {
+    lastRender = { data, location, model, config };
     const plot = document.getElementById('plot');
     if (!plot) return;
 
-    // Clear any existing Plotly chart / DOM
     if (window.Plotly && plot.classList && plot.classList.contains('js-plotly-plot')) {
       try { Plotly.purge(plot); } catch (_) {}
     }
     plot.innerHTML = '';
 
-    const hourly = data && data.forecast && data.forecast.hourly ? data.forecast.hourly : null;
+    const forecast = data && data.forecast ? data.forecast : null;
+    const hourly = forecast && forecast.hourly ? forecast.hourly : null;
     if (!hourly || !hourly.time || hourly.time.length === 0) {
       const msg = document.createElement('div');
       msg.style.cssText = 'padding:24px;text-align:center;color:#888;';
@@ -137,12 +237,10 @@ window.HourlyPanel = (function () {
     }
 
     const now = berlinNow();
-    const todayStr = now.toLocaleDateString('sv-SE'); // YYYY-MM-DD
-    const tomorrow = new Date(now);
-    tomorrow.setDate(tomorrow.getDate() + 1);
+    const todayStr = now.toLocaleDateString('sv-SE');
+    const tomorrow = new Date(now); tomorrow.setDate(tomorrow.getDate() + 1);
     const tomorrowStr = tomorrow.toLocaleDateString('sv-SE');
-    const currentHourStart = new Date(now);
-    currentHourStart.setMinutes(0, 0, 0);
+    const currentHourStart = new Date(now); currentHourStart.setMinutes(0, 0, 0);
 
     const T = hourly.time;
     const temp = hourly.temperature_2m || [];
@@ -153,24 +251,40 @@ window.HourlyPanel = (function () {
     const dir = hourly.wind_direction_10m || [];
     const precip = hourly.precipitation || [];
     const pop = hourly.precipitation_probability || [];
+    const isDayArr = hourly.is_day || [];
 
-    // Build per-hour records from the current hour onward, grouped by day.
+    const daily = forecast.daily || {};
+    const sunriseByDate = {}, sunsetByDate = {};
+    if (daily.time && daily.sunrise && daily.sunset) {
+      daily.time.forEach((d, i) => {
+        if (daily.sunrise[i]) sunriseByDate[d] = new Date(daily.sunrise[i]);
+        if (daily.sunset[i]) sunsetByDate[d] = new Date(daily.sunset[i]);
+      });
+    }
+
+    // Build full per-hour records from the current hour onward, grouped by day.
     const days = [];
     let lastDate = null;
     let nowMarked = false;
     for (let i = 0; i < T.length; i++) {
       const t = new Date(T[i]);
-      if (t < currentHourStart) continue; // skip past hours
+      if (t < currentHourStart) continue;
       const dateStr = T[i].slice(0, 10);
-      if (dateStr !== lastDate) {
-        days.push({ dateStr, hours: [] });
-        lastDate = dateStr;
+      if (dateStr !== lastDate) { days.push({ dateStr, hours: [] }); lastDate = dateStr; }
+
+      const isNow = !nowMarked; if (isNow) nowMarked = true;
+
+      let isDayVal = isDayArr.length ? isDayArr[i] : null;
+      if (isDayVal == null) {
+        const sr = sunriseByDate[dateStr], ss = sunsetByDate[dateStr];
+        isDayVal = (sr && ss) ? (t >= sr && t < ss ? 1 : 0) : 1;
       }
-      const isNow = !nowMarked;
-      if (isNow) nowMarked = true;
+
       days[days.length - 1].hours.push({
         hour: T[i].slice(11, 16),
+        t,
         isNow,
+        isDay: isDayVal,
         temp: round(temp[i]),
         code: code[i],
         uv: round(uv[i], 1),
@@ -187,7 +301,7 @@ window.HourlyPanel = (function () {
 
     const title = document.createElement('div');
     title.style.cssText = 'padding:6px 12px 2px;font-size:13px;color:#888;';
-    title.textContent = `${location && location.name ? location.name : ''} — hourly` +
+    title.textContent = `${location && location.name ? location.name : ''} — hourly · tap a tile to expand` +
       (model && model.label ? ` · ${model.label}` : '');
     container.appendChild(title);
 
@@ -202,12 +316,62 @@ window.HourlyPanel = (function () {
       ].join(';');
       container.appendChild(header);
 
+      // Group the day's hours into STEP_H blocks; show one tile per block unless
+      // the block is expanded, in which case show every hour in it.
+      const items = [];
+      let curKey = null;
+      day.hours.forEach(h => {
+        const key = blockKey(day.dateStr, h.t.getHours());
+        if (expanded.has(key)) {
+          items.push({ kind: 'hour', t: h.t, h, key });
+        } else if (key !== curKey) {
+          items.push({ kind: 'block', t: h.t, h, key }); // representative = first hour of block
+          curKey = key;
+        }
+      });
+
+      // Sunrise/sunset markers within the shown window.
+      const firstT = day.hours[0] ? day.hours[0].t : null;
+      const lastT = day.hours[day.hours.length - 1] ? day.hours[day.hours.length - 1].t : null;
+      const sr = sunriseByDate[day.dateStr], ss = sunsetByDate[day.dateStr];
+      if (sr && firstT && sr >= firstT && sr <= lastT) items.push({ kind: 'marker', t: sr, marker: { marker: 'sunrise', time: hhmm(sr) } });
+      if (ss && firstT && ss >= firstT && ss <= lastT) items.push({ kind: 'marker', t: ss, marker: { marker: 'sunset', time: hhmm(ss) } });
+      items.sort((a, b) => a.t - b.t);
+
       const row = document.createElement('div');
+      row.setAttribute('data-row-date', day.dateStr);
       row.style.cssText = [
         'display:flex', 'gap:6px', 'overflow-x:auto', 'scroll-snap-type:x mandatory',
         'padding:4px 12px 8px', '-webkit-overflow-scrolling:touch'
       ].join(';');
-      day.hours.forEach(h => row.appendChild(buildTile(h, h.isNow)));
+      // Render items; consecutive expanded hours of the same block are wrapped in
+      // a symmetric, tinted "expanded" group box so the drill-in reads clearly.
+      let j = 0;
+      while (j < items.length) {
+        const it = items[j];
+        if (it.kind === 'marker') { row.appendChild(buildMarkerTile(it.marker)); j++; continue; }
+        if (it.kind === 'block') {
+          const tile = buildHourTile(it.h, true, false);
+          tile.addEventListener('click', () => toggleBlock(it.key));
+          row.appendChild(tile);
+          j++;
+          continue;
+        }
+        // run of expanded hours sharing one block key
+        const key = it.key;
+        const group = document.createElement('div');
+        group.style.cssText = [
+          'flex:0 0 auto', 'display:flex', 'gap:6px', 'padding:4px', 'border-radius:14px',
+          'background:rgba(0,122,255,0.07)', 'border:1px solid rgba(0,122,255,0.30)'
+        ].join(';');
+        while (j < items.length && items[j].kind === 'hour' && items[j].key === key) {
+          const tile = buildHourTile(items[j].h, false, true);
+          tile.addEventListener('click', () => toggleBlock(key));
+          group.appendChild(tile);
+          j++;
+        }
+        row.appendChild(group);
+      }
       container.appendChild(row);
     });
 

--- a/js/main.js
+++ b/js/main.js
@@ -11,8 +11,16 @@ let measured_water_temp = null;
 // import { PANELS, PANEL_CONFIG, WEATHER_MODELS, LOCATIONS, DEFAULT_SETTINGS } from './config/appConfig.js';
 
 // For now, we'll define the configuration inline to maintain file:// compatibility
-const PANELS = ['temperature', 'overview', 'uv_wind', 'actuals', 'compare'];
+const PANELS = ['temperature', 'overview', 'uv_wind', 'actuals', 'compare', 'hourly'];
 const PANEL_CONFIG = {
+  hourly: {
+    enabled: true,
+    title: 'Hourly',
+    description: 'Swipeable hour tiles: symbol, temp, UV, wind, precipitation',
+    defaultView: '2d',
+    showEnsemble: false,
+    showCurrent: false
+  },
   temperature: {
     enabled: true,
     title: 'Temperature',
@@ -336,12 +344,15 @@ if (urlParams.model && models.find(m => m.id === urlParams.model)) {
 // Set panel from URL or default
 const panelSelect = document.getElementById('panelSelect');
 if (urlParams.panel && panelSelect) {
-  const validPanels = ['temperature', 'overview', 'uv_wind', 'actuals', 'compare'];
+  const validPanels = ['temperature', 'overview', 'uv_wind', 'actuals', 'compare', 'hourly'];
   if (validPanels.includes(urlParams.panel)) {
     panelSelect.value = urlParams.panel;
   }
 } else if (panelSelect) {
-  panelSelect.value = 'compare';
+  // Default panel: Overview on mobile (touch-friendly, links into Hourly),
+  // Compare on larger screens. Breakpoint matches the CSS mobile media query.
+  const isMobile = window.matchMedia('(max-width: 768px)').matches;
+  panelSelect.value = isMobile ? 'overview' : 'compare';
 }
 
 function updateModelRowVisibility() {
@@ -952,10 +963,10 @@ document.addEventListener('DOMContentLoaded', function() {
     if (isControlsVisible) {
       const h = controls.offsetHeight;
       plot.style.marginTop = h + 'px';
-      plot.style.height = `calc(100vh - ${h}px)`;
+      plot.style.height = `calc(100dvh - ${h}px)`;
     } else {
       plot.style.marginTop = '0px';
-      plot.style.height = '100vh';
+      plot.style.height = '100dvh';
     }
   }
 

--- a/js/main.js
+++ b/js/main.js
@@ -388,7 +388,7 @@ function toggleHelpOverlay() {
     ]},
     { title: '🧭 Navigation', rows: [
       ['← →', 'Pan time axis'], ['↑ ↓', 'Cycle panels'],
-      ['Swipe ←→', 'Pan time (controls hidden)'], ['Swipe ↑↓', 'Switch panel (controls hidden)'],
+      ['Swipe ←→', 'Pan time axis'],
     ]},
     { title: '🖥 Display', rows: [
       ['Esc', 'Show / hide controls'], ['?', 'This help screen'],

--- a/js/overviewPanel.js
+++ b/js/overviewPanel.js
@@ -370,6 +370,18 @@ window.OverviewPanel = {
         : 'box-shadow:0 2px 8px rgba(0,0,0,0.1)',
     ].join(';');
 
+    // Forecast day cards are clickable → jump to the Hourly panel for that day.
+    // Past (observed) days have no hourly forecast, so they stay non-interactive.
+    if (!isPast && day.date) {
+      card.style.cursor = 'pointer';
+      card.title = 'Show hourly forecast for this day';
+      card.addEventListener('click', () => {
+        window._hourlyScrollDate = day.date;
+        const sel = document.getElementById('panelSelect');
+        if (sel) { sel.value = 'hourly'; sel.dispatchEvent(new Event('change')); }
+      });
+    }
+
     // Day header
     const dayHeader = document.createElement('div');
     dayHeader.style.cssText = `

--- a/js/plot.js
+++ b/js/plot.js
@@ -455,7 +455,7 @@ window.WeatherPlot.renderWeatherData = async function(data, location, model, sel
     annotations: [...weekdayAnnotations, ...lastObsAnnotations]
   };
 
-  Plotly.newPlot('plot', allTraces, layout, { displayModeBar: false }).then(() => {
+  Plotly.newPlot('plot', allTraces, layout, { displayModeBar: false, doubleClick: false, scrollZoom: false }).then(() => {
     const plotDiv = document.getElementById('plot');
     const startTime = plotDiv.getAttribute('data-start-time');
     const endTime = plotDiv.getAttribute('data-end-time');
@@ -899,7 +899,7 @@ window.WeatherPlot.renderUVWindData = async function(data, location, model) {
     annotations: [...weekdayAnnotations, ...beaufortAnnotations, ...lastObsAnnotationsUV]
   };
 
-  Plotly.newPlot('plot', allTraces, layout, { displayModeBar: false }).then(() => {
+  Plotly.newPlot('plot', allTraces, layout, { displayModeBar: false, doubleClick: false, scrollZoom: false }).then(() => {
     const plotDiv = document.getElementById('plot');
     const startTime = plotDiv.getAttribute('data-start-time');
     const endTime = plotDiv.getAttribute('data-end-time');

--- a/js/swipeNavigation.js
+++ b/js/swipeNavigation.js
@@ -47,10 +47,10 @@ window.SwipeNavigation = {
       if (adx >= this.minSwipeDistance && adx > ady * 1.5) {
         // Horizontal — pan time axis (map-drag convention: swipe left = later time)
         this.panTime(dx > 0 ? 'left' : 'right');
-      } else if (ady >= this.minSwipeDistance && ady > adx * 1.5) {
-        // Vertical — switch panel
-        this.switchPanel(dy > 0 ? 'down' : 'up');
       }
+      // Vertical swipe intentionally does nothing: it collided with normal
+      // page/panel scrolling and switched panels by accident. Use the panel
+      // dropdown or the ↑/↓ keys (handled in main.js) to change panels.
     }
     this.reset();
   },
@@ -100,16 +100,6 @@ window.SwipeNavigation = {
       transition: { duration: 600, easing: 'ease-out' },
       frame:      { duration: 600, redraw: false }
     });
-  },
-
-  switchPanel: function(direction) {
-    const sel = document.getElementById('panelSelect');
-    if (!sel) return;
-    const n = sel.options.length;
-    sel.selectedIndex = direction === 'up'
-      ? (sel.selectedIndex - 1 + n) % n
-      : (sel.selectedIndex + 1) % n;
-    sel.dispatchEvent(new Event('change'));
   },
 
   reset: function() {

--- a/js/visRegistry.js
+++ b/js/visRegistry.js
@@ -253,6 +253,18 @@ window.VisRegistry = {
     plot.appendChild(container);
   },
 
+  /**
+   * Hourly panel visualizer
+   * Renders swipeable hour tiles (symbol, temp, UV, wind, precipitation). No Plotly.
+   */
+  hourly: function(data, location, model, config = {}) {
+    if (!window.HourlyPanel || !window.HourlyPanel.render) {
+      console.error('HourlyPanel module not available');
+      return;
+    }
+    window.HourlyPanel.render(data, location, model, config);
+  },
+
   compare: function(data, location, model, config = {}) {
     if (!window.ComparePanel || !window.ComparePanel.render) {
       console.error('ComparePanel module not available');


### PR DESCRIPTION
## Summary
Adds a mobile-first **Hourly** panel and a batch of mobile usability fixes.

### New 🕒 Hourly panel
- Vertical day groups, each a horizontally **swipeable row of hour tiles** (CSS scroll-snap, native touch momentum — no gesture JS).
- Each tile: weather symbol, temperature, UV, wind (speed + direction arrow), and **precipitation probability + amount**.
- "Now" tile highlighted; starts at the current Berlin hour.
- No Plotly — pure DOM under `#plot` (same pattern as `actuals`), `file://`-safe. Registered in `VisRegistry`, `main.js` (`PANELS`/`PANEL_CONFIG`/`validPanels`), and `index.html`.

### Overview → Hourly link
- Forecast day cards in 📅 Overview are now clickable and jump to the Hourly panel scrolled to that day. Past (observed) days stay non-interactive.

### Mobile defaults & UX
- Default panel: **Overview on mobile** (≤768px), **Compare** on larger screens. Explicit `panel=` deep links unaffected.
- Charts no longer reset/zoom-out on tap or double-tap (`doubleClick: false`, `scrollZoom: false` on all three Plotly charts); the custom 1d/2d/5d/All buttons stay authoritative.
- `100vh → 100dvh` (CSS + JS) to avoid URL-bar jump/clip.
- Safe-area insets for fixed controls, `#fade-button`, `#help-button` (notch/Dynamic Island).
- Re-enabled pinch-zoom (`viewport-fit=cover`, dropped `maximum-scale`/`user-scalable=no`).
- Slimmer control bar on mobile (compact view buttons fit one row).

### Docs
- README panel table and AGENTS.md updated for the new panel.

## Testing
- All JS syntax-checked (`node --check`).
- Verified in-browser that double-tapping a chart no longer resets the view.
- Mobile layout changes (control bar / safe-area / dvh) verified by code; best confirmed on a real phone viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WyoyjiNBWrnHNFfmHiHUuJ